### PR TITLE
Fix FixFileNotFoundException during authorization

### DIFF
--- a/Spotify4Unity/Assets/Spotify4Unity/Core/Managed Authentification/PKCE/PKCE_Authentification.cs
+++ b/Spotify4Unity/Assets/Spotify4Unity/Core/Managed Authentification/PKCE/PKCE_Authentification.cs
@@ -250,6 +250,10 @@ public class PKCE_Authentification : MonoBehaviour, IServiceAuthenticator
             // Load token from File
             if (!string.IsNullOrEmpty(PKCEConfig.TokenPath))
             {
+                if (!File.Exists(PKCEConfig.TokenPath))
+                {
+                    return null;
+                }
                 string previousToken = File.ReadAllText(PKCEConfig.TokenPath);
                 if (string.IsNullOrEmpty(previousToken))
                 {


### PR DESCRIPTION
Checks if auth token file exists before trying to read the token.

Fixes #43 